### PR TITLE
fix(list): removes the link from the "No Content" hint from the list

### DIFF
--- a/src/components/List.css
+++ b/src/components/List.css
@@ -32,6 +32,10 @@
   background-color: #DEE4E9;
   cursor:default;
 }
+.disabled {
+  cursor: default !important;
+  background-color: transparent !important;
+}
 .list li:hover {
   background-color: #DEE4E9;
   cursor: pointer;

--- a/src/components/entries/EntryListItem.js
+++ b/src/components/entries/EntryListItem.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import { Link } from 'react-router'
-import { current } from '../List.css'
+import { current, disabled } from '../List.css'
 
 export default function EntryListItem ({item, location}) {
-  const contentType = item.sys.contentType
   function getClassIfCurrentlySelected () {
     const pathnames = location.pathname.split('/')
     if (pathnames.indexOf(contentType.sys.id) >= 0 && pathnames.indexOf(item.sys.id) >= 0) {
@@ -11,11 +10,26 @@ export default function EntryListItem ({item, location}) {
     }
     return ''
   }
-  return (
-    <li className={getClassIfCurrentlySelected()}>
+  const contentType = item.sys.contentType
+  let content
+  let className = getClassIfCurrentlySelected()
+
+  if (item.fields[contentType.displayField]) {
+    content = (
       <Link to={{pathname: `/entries/by-content-type/${contentType.sys.id}/${item.sys.id}`, query: location.query}}>
-      {item.fields[contentType.displayField] || 'No Content'}
+        {item.fields[contentType.displayField]}
       </Link>
+    )
+  } else {
+    content = (
+      <p>No Content</p>
+    )
+    className = disabled
+  }
+
+  return (
+    <li className={className}>
+      {content}
     </li>
   )
 }


### PR DESCRIPTION
Since the `No Content` information was clickable, the user could get stuck in the app.

This fixes it. Decided to go for a extra class with `!important` to avoid adding extra classes to every clickable element. Since that would have resulted in more css and js changes.