### PR TITLE
Fix base64 url vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "flux": "^2.1.1",
     "history": "^2.0.1",
     "localforage": "^1.4.0",
-    "marked": "^0.3.5",
+    "marked": "^0.3.6",
     "pretty-bytes": "^3.0.1",
     "react": "^15.0.0-rc.1",
     "react-ace": "^3.4.1",

--- a/src/components/entries/Field.js
+++ b/src/components/entries/Field.js
@@ -60,7 +60,7 @@ function renderMarkdown (content) {
   }
 }
 function removeIvalidDataURL (content) {
-  let regex = /data:\w+;base64\S*/gm 
+  let regex = /data:\S+;base64\S*/gm 
   return content.replace(regex, '#')
 }
 function renderEntryLink (content, location) {

--- a/src/components/entries/Field.js
+++ b/src/components/entries/Field.js
@@ -56,10 +56,13 @@ function renderContent (content, definition, location) {
 
 function renderMarkdown (content) {
   return {
-    __html: marked(content, {sanitize: true})
+    __html: marked(removeIvalidDataURL(content), {sanitize: true})
   }
 }
-
+function removeIvalidDataURL (content) {
+  let regex = /data:\w+;base64\S*/gm 
+  return content.replace(regex, '#')
+}
 function renderEntryLink (content, location) {
   return <EntryLinkContainer entryLink={content} location={location} />
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,7 +2437,7 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
-marked@^0.3.5:
+marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 


### PR DESCRIPTION
We use marked as a markdown parser which is doing a good job already at sanitizing the HTML but Andy found a flaw in there that allows you to inject a base 64 injected javascript in the link .

This PR fixes that but clearing all urls that contains `data:*;base64`